### PR TITLE
ios NSContactsUsageDescription

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,5 +44,10 @@
         <framework src="AddressBook.framework" weak="true" />
         <framework src="AddressBookUI.framework" weak="true" />
         <framework src="CoreGraphics.framework" />
+
+        <preference name="CONTACTS_USAGE_DESCRIPTION" default="This app needs contacts access"/>
+        <config-file target="*-Info.plist" parent="NSContactsUsageDescription">
+            <string>$CONTACTS_USAGE_DESCRIPTION</string>
+        </config-file>
     </platform>
 </plugin>


### PR DESCRIPTION
According to the official plugin documentation:

> Since iOS 10 it's mandatory to provide an usage description in the info.plist if trying to access privacy-sensitive data. When the system prompts the user to allow access, this usage description string will displayed as part of the permission dialog box, **but if you didn't provide the usage description, the app will crash before showing the dialog**. Also, Apple will reject apps that access private data but don't provide an usage description.

To change the permission dialog text you need to install plugin with CONTACTS_USAGE_DESCRIPTION variable: 
`cordova plugin add cordova-plugin-contacts-phonenumbers --variable CONTACTS_USAGE_DESCRIPTION="custom text"`
Or you can add it manually to config.xml file:
```
<plugin name="cordova-plugin-contacts-phonenumbers" spec="0.0.11">
        <variable name="CONTACTS_USAGE_DESCRIPTION" value="custom text" />
</plugin>
```